### PR TITLE
Fix getting bulletins lately modified

### DIFF
--- a/src/main/java/fi/hsl/transitdata/omm/db/BulletinDAOImpl.java
+++ b/src/main/java/fi/hsl/transitdata/omm/db/BulletinDAOImpl.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 
 public class BulletinDAOImpl extends DAOImplBase implements BulletinDAO {
 
+    private static final int fiveMinutesInSeconds = 60 * 5; //Added to give query some tolerance to work with.
+
     String queryString;
     String timezone;
     int pollIntervalInSeconds;
@@ -32,7 +34,7 @@ public class BulletinDAOImpl extends DAOImplBase implements BulletinDAO {
             String now = localDatetimeAsString(timezone);
             statement.setString(1, now);
             if (queryAllModifiedAlerts) {
-                String pastNow = pastLocalDatetimeAsString(timezone, pollIntervalInSeconds);
+                String pastNow = pastLocalDatetimeAsString(timezone, pollIntervalInSeconds - fiveMinutesInSeconds);
                 statement.setString(2, pastNow);
             }
 


### PR DESCRIPTION
Added some (5min) tolerance to query parameter that is used to determine how far in history we're looking for modified bulletins. This should fix problem where cancelling bulletin doesn't actually show up in UI due to too accurate timing window.